### PR TITLE
Update draft-amend-tsvwg-multipath-dccp.mkd

### DIFF
--- a/draft-amend-tsvwg-multipath-dccp.mkd
+++ b/draft-amend-tsvwg-multipath-dccp.mkd
@@ -68,8 +68,9 @@ author:
   ins: S. Johnson
   name: Stephen Johnson
   org: BT
-  street: Northampton Square
-  city: London
+  street: Adastral Park
+  city: Martlesham Heath
+  code: IP5 3RE
   country: United Kingdom
   email: stephen.h.johnson@bt.com
   
@@ -93,12 +94,12 @@ informative:
   RFC6904:
   RFC6951:
   RFC8684:
-  TR23.793:
-    title: Study on access traffic steering, switch and splitting support in the 5G
-      System (5GS) architecture
+  TS23.501:
+    title: System architecture for the 5G System; Stage 2; Release 16
     author:
     - org: 3GPP
-    date: '2018-12-19'
+    date: '2020-12-17'
+	target: https://www.3gpp.org/ftp//Specs/archive/23_series/23.501/23501-g70.zip
 
 --- abstract
 
@@ -137,8 +138,8 @@ in the context of ongoing 3GPP work on 5G multi-access solutions
 {{I-D.amend-tsvwg-multipath-framework-mpdccp}} and for hybrid access
 networks {{I-D.lhwxz-hybrid-access-network-architecture}}{{I-D.muley-network-based-bonding-hybrid-access}}.
 It can be applied for load-balancing, seamless session handover, and
-aggregation purposes (referred to as steering, switching, and splitting
-in 3GPP terminology {{TR23.793}}).
+aggregation purposes (referred to as ATSSS; Access steering, switching, and splitting
+in 3GPP terminology {{TS23.501}}).
 
 This document presents the protocol changes required to add multipath
 capability to DCCP; specifically, those for signaling and setting up


### PR DESCRIPTION
Updated my contact details.

Thought it would be better to refer to the 3GPP architecture document TS 23.501 instead of the ATSSS study TR 23.793. The study proposes a number of solutions, the architecture doc is the definitive reference for ATSSS.