### PR TITLE
#20 unifying terms4 reordering

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -340,18 +340,16 @@ communication establishment if at least one functional path is
 available.  MPTCP relies on an initial path, which has to work;
 otherwise no communication can be established.
 
-The receiver side for MP-DCCP has to deal with the unreliable
-transport character of DCCP, and a possible reordering of the data 
-stream, while not advocating it. Many applications that also use unreliable transport
-protocols have built-in handling of out of sequence data (such as adaptive audio 
-and video buffers), and so additional reordering support may not be required.
-However, MP-DCCP can provide flexible handling of reordering for those applications
-where it is beneficial.
-
-Such optional reordering mechanisms are most likely to be required when 
-the different DCCP subflows are routed across paths with different 
-latencies. In theory, applications using DCCP are aware that packet 
-reordering might happen, since DCCP has no mechanisms to prevent it. 
+The receiver side for MP-DCCP has to deal with the unreliable transport 
+character of DCCP, and can provide flexible handling for data stream packet 
+reordering for those applications where it is beneficial. However, many 
+applications that use unreliable transport protocols can inherently deal 
+with out of sequence data (e.g. through adaptive audio and video buffers), 
+and so additional reordering support may not be required. The optional 
+reordering mechanisms in MP-DCCP are most likely to be required when the 
+different DCCP subflows are routed across paths with different latencies. 
+In theory, applications using DCCP are aware that packet reordering might 
+happen, since DCCP has no mechanisms to prevent it.
 
 The receiving process for MPTCP is on the other hand a rigid
 "just wait" approach, since TCP guarantees reliable delivery.

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -374,9 +374,9 @@ not gracefully handle multiple congestion control mechanisms, for example.
 
 The operation of MP-DCCP for data transfer takes one input data stream
 from an application, and splits it into one or more subflows, with
-sufficient control information to allow received data to be re-assembled and
-delivered in order to the recipient application. The
-following subsections define this behavior in detail.
+sufficient control information to allow received data to be re-assembled 
+for in order delivery to the recipient application. The following 
+subsections define this behavior in detail.
 
 The Multipath Capability for MP-DCCP can be negotiated with a new DCCP
 feature, as described in {{protocol}}.

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -345,7 +345,7 @@ character of DCCP, and can provide flexible handling for data stream packet
 reordering for those applications where it is beneficial. However, many 
 applications that use unreliable transport protocols can inherently deal 
 with out of sequence data (e.g. through adaptive audio and video buffers), 
-and so additional reordering support may not be required. The optional 
+and so additional reordering support may not be necessary. The optional 
 reordering mechanisms in MP-DCCP are most likely to be required when the 
 different DCCP subflows are routed across paths with different latencies. 
 In theory, applications using DCCP are aware that packet reordering might 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -187,7 +187,7 @@ in 3GPP terminology {{TS23.501}}).
 
 This document presents the protocol changes required to add multipath
 capability to DCCP; specifically, those for signaling and setting up
-multiple paths ("subflows"), managing these subflows, re-assembly of
+multiple paths ("subflows"), managing these subflows, reordering of
 data, and termination of sessions.
 DCCP, as stated in {{RFC4340}} does not provide reliable and ordered
 delivery. Consequently, multiple application subflows may be multiplexed over a
@@ -329,7 +329,7 @@ congestion control.
 | Session handover             | yes                   | yes                |
 | Path aggregation             | yes                   | yes                |
 | Robust session establishment | no                    | yes                |
-| Data re-assembly             | yes                   | optional / modular |
+| Data reordering              | yes                   | optional / modular |
 | Expandability                | limited by TCP header | flexible           |
 {: #table_mptcp_mpdccp_comp title='MPTCP and MP-DCCP protocol comparison'}
 
@@ -341,16 +341,14 @@ available.  MPTCP relies on an initial path, which has to work;
 otherwise no communication can be established.
 
 The receiver side for MP-DCCP has to deal with the unreliable
-transport character of DCCP and a possible re-assembly of the data 
-stream while not advocating it. As many unreliable applications have 
-built-in application support for reordering (such as adaptive audio 
-and video buffers), those applications might not need support for 
-re-assembly. However, for applications that benefit from partial or 
-full support of reordering, MP-DCCP can provide flexible support for 
-re-assembly, even if for DCCP the order of delivery is unreliable 
-by nature. Such optional re-assembly mechanisms may account for the 
-fact that packet loss may occur for any of the DCCP subflows. 
-Another issue may occur as packet reordering may happen when 
+transport character of DCCP, and a possible reordering of the data 
+stream, while not advocating it. Many applications that also use unreliable transport
+protocols have built-in handling of out of sequence data (such as adaptive audio 
+and video buffers), and so additional reordering support may not be required.
+However, MP-DCCP can provide flexible handling of reordering for those applications
+where it is beneficial.
+
+Such optional reordering mechanisms are most likely to be required when 
 the different DCCP subflows are routed across paths with different 
 latencies. In theory, applications using DCCP are aware that packet 
 reordering might happen, since DCCP has no mechanisms to prevent it. 
@@ -450,7 +448,7 @@ considerations for:
   Changes of individual path PMTUs must be re-announced to the application
   if they result in a value lower than the currently announced PMTU.
 
-* Overall sequencing for optional re-assembly procedure
+* Overall sequencing for optional reordering procedure
 
 * Congestion control
 


### PR DESCRIPTION
Replaced use of re-assembly with reorder and reworded slightly to read better. However, left one use of re-assembled in the Operation overview as this makes sense here.

**Also removed the sentence "_Such optional reordering mechanisms may account for the fact that packet loss may occur for any of the DCCP subflows_" as I think this is incorrect - happy to discuss. Packet loss will cause the reordering mechanism to introduce the maximum delay (based on the length of the reordering buffer), but no reordering happens.**

