### PR TITLE
Fix issues #26 and #27

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -507,9 +507,9 @@ use.
 ~~~~
 
 MP_CONFIRM is used to send confirmation of reception and processing of the multipath 
-options that require it (See {{ref-mp-option-confirm}}). Such options will be retransmitted by the sender 
-until this receives the cooresponding MP_CONFIRM. The length and sending path of the MP_CONFIRM are dependent 
-on the confirmed options, which will be copied verbatim and appended as List of options.
+options that require it (see {{ref-mp-option-confirm}}). Such options will be retransmitted by the sender 
+until this receives the corresponding MP_CONFIRM. The length and sending path of the MP_CONFIRM are dependent 
+on the confirmed options, which will be copied verbatim and appended as list of options.
 
 
 


### PR DESCRIPTION
I added the description of the MP_CONFIRM option as the mechanism to provide reliable exchange of MP_OPTIONS, as well as a table specifying the options that require confirmation and its return path. The previous description of the MP_CONFIRM option stated that "Confirmed options are copied verbatim and appended as List of options", I'm not sure if that is necessary (or maybe it's better just to append the option IDs), but I leave it there for discussion.