### PR TITLE
3.4 Fallback section added

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -876,8 +876,8 @@ handshake procedure it appears that DCCP-Request or DCCP-response or DCCP-Ack
 messages don’t have the MP-DCCP options, the MP-DCCP connection will not be 
 established and the handshake should fall back to regular DCCP. 
 
-If a path attempts to join an existing MP-DCCP connection, but MP-DCCP options 
-are not present in the handshake messages, the subflow will be closed.   
+If a subflow attempts to join an existing MP-DCCP connection, but MP-DCCP options 
+are not present in the handshake messages, that subflow will be closed.   
 
 
 


### PR DESCRIPTION
Fallback section added. This is just a start, needs to be discussed. In most use cases we discuss, MP-DCCP is used to carry other traffic, so falling back on DCCP may not make much sense.