### PR TITLE
Remove Tbd : MP_CONFIRM encoding list of options

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -598,9 +598,6 @@ on the confirmed options, which will be copied verbatim and appended as list of 
 {: #ref-mp-option-confirm title='Multipath options requiring confirmation'}
 
 
-
-[Tbd] Encoding "list of options"
-
 ### MP_JOIN {#MP_JOIN}
 
 


### PR DESCRIPTION
close #49 . No encoding is necessary, as the text states that the options to be confirmed must be copied verbatim.