### PR TITLE
Edits to Section "3.  MP-DCCP Protocol"

### DIFF
--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -375,26 +375,14 @@ signaled with MP-DCCP options described in detail in {#MP_OPT}.
 
 # MP-DCCP Protocol {#protocol}
 
-The DCCP protocol feature list ({{RFC4340}} section 6.4) will be
-enhanced by a new Multipath related feature with Feature number 10, as
+The DCCP protocol feature list ({{RFC4340}}, Section 6.4) are
+enriched with a new Multipath related feature with Feature number 10, as
 shown in {{ref-feature-list}}.
 
 |Number | Meaning                      | Rule | Rec'n Value | Initial Req'd |
 |:-----:|:-----------------------------|:----:|:-----------:|:-------------:|
-|   0   | Reserved                     |      |             |               |
-|   1   | Congestion Control ID (CCID) |  SP  |      2      |       Y       |
-|   2   | Allow Short Seqnos           |  SP  |      0      |       Y       |
-|   3   | Sequence Window              |  NN  |     100     |       Y       |
-|   4   | ECN Incapable                |  SP  |      0      |       N       |
-|   5   | Ack Ratio                    |  NN  |      2      |       N       |
-|   6   | Send Ack Vector              |  SP  |      0      |       N       |
-|   7   | Send NDP Count               |  SP  |      0      |       N       |
-|   8   | Minimum Checksum Coverage    |  SP  |      0      |       N       |
-|   9   | Check Data Checksum          |  SP  |      0      |       N       |
 |   10  | Multipath Capable            |  SP  |      0      |       N       |
-| 11-127| Reserved                     |      |             |               |
-|128-255| CCID-specific features       |      |             |               |
-{: #ref-feature-list title='Proposed Feature Set'}
+{: #ref-feature-list title='Multipath Feature'}
 
 Rec'n Rule:
 : The reconciliation rule used for the feature. SP means server-priority,
@@ -405,39 +393,18 @@ Initial Value:
 
 Req'd:
 : This column is "Y" if and only if every DCCP implementation MUST
-understand the feature. If it is "N", then the feature behaves like an extension
-(see Section 15), and it is safe to respond to Change options for the feature
-with empty Confirm options. Of course, a CCID might require the feature; a DCCP
-that implements CCID 2 MUST support Ack Ratio and Send Ack Vector, for example.
+understand the feature. If it is "N", then the feature behaves like an extension, and it is safe to respond to Change options for the feature
+with empty Confirm options.
 
-The DCCP protocol options as defined in ({{RFC4340}} section 5.8) and ({{RFC5634}} section 2.2.1) will be enhanced
-by a new Multipath related variable-length option with option type 46, as
+The DCCP protocol options as defined in ({{RFC4340}}, Section 5.8) and ({{RFC5634}}, Section 2.2.1) are enriched with 
+a new Multipath related variable-length option with option type 46, as
 shown in {{ref-option-list}}.
 
 | Type  | Option Length | Meaning               | DCCP-Data? |
 |:-----:|:-------------:|:---------------------:|:----------:|
-|   0   |       1       | Padding               |     Y      |
-|   1   |       1       | Mandatory             |     N      |
-|   2   |       1       | Slow Receiver         |     Y      |
-| 3-31  |       1       | Reserved              |            |
-|  32   |    variable   | Change L              |     N      |
-|  33   |    variable   | Confirm L             |     N      |
-|  34   |    variable   | Change R              |     N      |
-|  35   |    variable   | Confirm R             |     N      |
-|  36   |    variable   | Init Cookie           |     N      |
-|  37   |      3-8      | NDP Count             |     Y      |
-|  38   |    variable   | Ack Vector \[Nonce 0\]|     N      |
-|  39   |    variable   | Ack Vector \[Nonce 1\]|     N      |
-|  40   |    variable   | Data Dropped          |     N      |
-|  41   |       6       | Timestamp             |     Y      |
-|  42   |     6/8/10    | Timestamp Echo        |     Y      |
-|  43   |      4/6      | Elapsed Time          |     N      |
-|  44   |       6       | Data Checksum         |     Y      |
-|  45   |       8       | Quick-Start Response  |     ?      |
 |  46   |    variable   | Multipath             |     Y      |
-| 47-127|    variable   | Reserved              |            |
-|128-255|    variable   | CCID-specific options |     -      |
-{: #ref-option-list title='Proposed Option Set'}
+
+{: #ref-option-list title='Multipath Option Set'}
 
 
 ## Multipath Capable Feature {#mp_capable}


### PR DESCRIPTION
no need to be redundant, but focus only on the new codepoints. 

The IANA registry is authoritative here.