### PR TITLE
Gorry's early review

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -93,6 +93,7 @@
        "RTTs",
        "SEQs",
        "seqno",
-       "Ferlin"
+       "Ferlin",
+       "DTLS"
     ]
 }

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -634,7 +634,7 @@ Address A1    Address A2                     Address B1    Address B2
 {: #ref-MP_JOIN title='Format of the MP_JOIN Suboption'}
 
 The MP_JOIN option is used by a host to add a new subflow to an existing MP-DCCP
-connection and REQUIRES a successfull establishment of the first subflow using MP_KEY.
+connection and REQUIRES a successful establishment of the first subflow using MP_KEY.
 The Path Token is the SHA256 hash of the derived key (d-key),
 which was previously exchanged with the MP_KEY option.
 MP_HMAC MUST be set when using MP_JOIN to provide authentication (See
@@ -774,7 +774,7 @@ number (IDSN) SHOULD be set randomly {{RFC4086}}.
 
 The MP_SEQ number space is
 different from the path individual sequence number space and MUST be
-sent with any DCCP-Data and DCCP-DataACK packet.
+sent with all DCCP-Data and DCCP-DataACK packet.
 
 
 ### MP_HMAC {#MP_HMAC}
@@ -807,8 +807,8 @@ described in {{MP_KEY}}, while the HMAC "Message" is a concatenation of
    * MP_REMOVEADDR: Solely the Address ID.
 
 MP_JOIN, MP_ADDADDR and MP_REMOVEADDR can co-exist or be used multiple times
-within a single DCCP packet. As all this multipath options come along with an
-individual MP_HASH option, this requires the MP_HASH to be correctly associated.
+within a single DCCP packet. All these multipath options include an individual
+MP_HASH option. This ensures the MP_HASH is correctly associated.
 Otherwise, the receiver cannot validate multiple MP_JOIN, MP_ADDADDR or
 MP_REMOVEADDR. Therefore, a MP_HASH MUST directly follow its associated multipath
 option. In the likely case of sending a MP_JOIN together with a MP_ADDADDR, this
@@ -818,8 +818,8 @@ MP_ADDADDR suboption.
 
 If the HMAC can not be validated by a receiving host, the subsequent handling depends
 on which suboption was being authenticated. If the suboption to be authenticated was either
-MP_ADDADDR or MP_REMOVEADDR, the receiving host SHOULD silently ignore it (see {{MP_ADDADDR}} and {{MP_REMOVEADDR}}). 
-If the suboption to be authenticated was MP_JOIN, it MUST lead to a subflow closing (see {{fallback}})
+MP_ADDADDR or MP_REMOVEADDR, the receiving host MUST silently ignore it (see {{MP_ADDADDR}} and {{MP_REMOVEADDR}}). 
+If the suboption to be authenticated was MP_JOIN, the subflow MUST be closed (see {{fallback}})
 
 ### MP_RTT {#MP_RTT}
 
@@ -877,7 +877,7 @@ RTT values might be extracted from the sender's Congestion Control procedure and
 carried to the receiving host using MP_RTT suboption. With the reception of RTT1
 and RTT2, the receiver is able to calculate the path_delta which corresponds to
 the absolute difference of both values.
-In case the path individual RTTs are symmetric in down- and uplink direction, packets
+In the case that the path individual RTTs are symmetric in down- and uplink direction, packets
 with missing sequence number MP_SEQ, e.g., in a reordering process, can be assumed
 lost after path_delta/2.
 
@@ -910,11 +910,11 @@ use, are optional and can be inferred from the length of the option.
 Although it is expected that the majority of use cases will use the
 same port pairs as used for the initial subflow (e.g., port 80
 remains port 80 on all subflows, as does the ephemeral port at the
-client), there may be cases (such as port-based load balancing) where
+client), there could be cases (such as port-based load balancing) where
 the explicit specification of a different port is required.  If no
-port is specified, the receiving peer SHOULD assume that any attempt to
-connect to the specified address has to be on the same port as is already
-in use by the subflow on which the MP_ADDADDR signal was sent.
+port is specified, the receiving peer MUST assume that any attempt to
+connect to the specified address uses the port already used by the
+subflow on which the MP_ADDADDR signal was sent.
 
 Along with the MP_ADDADDR option a MP_HMAC option MUST be sent for
 authentication. The truncated HMAC parameter present in this MP_HMAC
@@ -949,7 +949,7 @@ in which MP_ADDADDR is sent. Further details are given in {{MP_CONFIRM}}.
   +-------------------------------+
        Type=46         Length         MP_OPT=7
 ~~~~
-{: #refMP_ADDADDR title='Format of the MP_ADDADDR Suboption'}
+{: #ref-MP_ADDADDR title='Format of the MP_ADDADDR Suboption'}
  
 Every address has an Address ID that can be used for uniquely
 identifying the address within a connection for address removal. The
@@ -965,7 +965,7 @@ Address-ID-to-address mappings for a connection (identified by a token
 pair). In this way, there is a stored mapping between the Address ID,
 observed source address, and token pair for future processing of control
 information for a connection. Note that an implementation
-MAY discard incoming address advertisements at will, for example, for
+MAY discard incoming address advertisements, for example, for
 avoiding the required mapping state, or because advertised addresses
 are of no use to it (for example, IPv6 addresses when it has IPv4
 only).  Therefore, a host MUST treat address advertisements as soft
@@ -974,8 +974,8 @@ state, and it MAY choose to refresh advertisements periodically.
 Due to the proliferation of NATs, it is reasonably likely that one
 host may attempt to advertise private addresses.  It is not
 desirable to prohibit this, since there may be cases where both hosts
-have additional interfaces on the same private network, and a host
-MAY want to advertise such addresses. The MP_JOIN handshake to
+have additional interfaces on the same private network. A host
+MAY advertise a private addresses. The MP_JOIN handshake to
 create a new subflow ({{MP_JOIN}}) provides mechanisms to minimize
 security risks.  The MP_JOIN message contains a 32-bit token that
 uniquely identifies the connection to the receiving host. If the

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -74,7 +74,6 @@ informative:
   RFC0793:
   RFC2104:
   RFC2119:
-  RFC3124:
   RFC3711:
   RFC4043:
   RFC4086:
@@ -82,7 +81,6 @@ informative:
   RFC5595:
   RFC5596:
   RFC5597:
-  RFC5634:
   RFC6234:
   RFC6356:
   RFC6773:
@@ -357,12 +355,10 @@ Address A1    Address A2             Address B1    Address B2
 DCCP (Section 17.2 of {{RFC4340}}) allows multiple application 
 subflows to be multiplexed over a single DCCP connection with 
 potentially same performance. However, DCCP does not provide built-in 
-support for multiple subflows and the Congestion Manager (CM) 
-{{RFC3124}}, as a generic multiplexing facility, can not fully support 
-multiple congestion control mechanisms for multiple DCCP flows between 
-same source and destination addresses. Various congestion control mechanisms 
-have been specified to optimize DCCP performance for specific traffic types 
-in terms of profiles denoted by a Congestion Control IDentifier (CCID).
+support for managing multiple subflows within one DCCP connection.
+Various congestion control mechanisms have been specified to optimize
+DCCP performance for specific traffic types in terms of profiles denoted
+by a Congestion Control IDentifier (CCID).
 
 The extension of DCCP towards Multipath-DCCP (MP-DCCP) is 
 described in detail in {{protocol}}.
@@ -372,8 +368,9 @@ stream from a DCCP application is split
 by MP-DCCP operation into one or more subflows which can be 
 transmitted via different also physically isolated paths.
 The corresponding control information allows the receiver to optionally 
-re-assemble and deliver the received data in the right order to the 
-recipient application. The details of the transmission scheduling mechanism and 
+re-assemble and deliver the received data in the originally transmitted order to the 
+recipient application. This may be necessary because DCCP does not guarantee in-order delivery.
+The details of the transmission scheduling mechanism and 
 optional reordering mechanism are up to the sender and receiver, respectively,
 and are outside the scope of this document.
 
@@ -394,7 +391,7 @@ negotiated, all subsequent MP-DCCP operations for that connection are signalled 
 variable length multipath-related option, as described in {{protocol}}.
 All MP-DCCP operations are signaled with MP-DCCP suboptions described in {#MP_OPT}.
 
-The number of concurrent DCCP subflows can vary during the 
+The number of DCCP subflows can vary during the 
 lifetime of a Multipath DCCP connection. The details of the path management decisions for
 when to add or remove subflows are outside the scope of this document.
 
@@ -422,7 +419,7 @@ Req'd:
 understand the feature. If it is "N", then the feature behaves like an extension, and it is safe to respond to Change options for the feature
 with empty Confirm options.
 
-The DCCP protocol options as defined in ({{RFC4340}}, Section 5.8) and ({{RFC5634}}, Section 2.2.1) are enriched with 
+The DCCP protocol options as defined in ({{RFC4340}}, Section 5.8) are enriched with 
 a new Multipath related variable-length option with option type 46, as
 shown in {{ref-option-list}}.
 
@@ -434,9 +431,9 @@ shown in {{ref-option-list}}.
 
 ## Multipath Capable Feature {#mp_capable}
 
-DCCP endpoints uses the Multipath Capable Feature to decide whether multipath extensions can be enabled for a DCCP connection.
+DCCP endpoints negotiates the Multipath Capable Feature to decide whether multipath extensions can be enabled for a DCCP connection.
 
-Multipath Capable feature has feature number 10 and has length of one-byte.
+Multipath Capable feature (MP_CAPABLE) has feature number 10 and has length of one-byte.
 The leftmost four bits are used to specify a compatible version of the
 MP-DCCP implementation (0000 for this specification). The following four bits are unassigned in version 0. The unassigned bits MUST be set to zero by the sender and MUST be ignored by the receiver.
 
@@ -446,14 +443,15 @@ MP-DCCP implementation (0000 for this specification). The following four bits ar
    |  Version  | Unassigned |
    +-----------+------------+
 ~~~~
+{: #ref-mp-capable-format title='Format of the Multipath Capable feature'}
 
-The setting of Multipath Capable MUST follow the server-priority reconciliation rule described
+The setting of the MP_CAPABLE feature MUST follow the server-priority reconciliation rule described
 in ({{RFC4340}}, Section 6.3.1), which allows multiple versions to be
 specified in order of priority.
 
 The negotiation MUST be done as part of the initial handshake procedure
 as described in {{handshaking}}, and no subsequent re-negotiation of
-the Multipath Capable feature is allowed on the same MP-DCCP connection.
+the MP_CAPABLE feature is allowed on the same MP-DCCP connection.
 
 Clients MUST include a Change R option during the initial handshake request to
 supply a list of supported MP-DCCP protocol versions, ordered by preference.
@@ -472,14 +470,15 @@ An example of successful version negotiation is shown hereafter:
 ~~~~
       Client                                             Server
       ------                                             ------
-      DCCP-Req + Change R(CAPABLE, 1 0)
+      DCCP-Req + Change R(MP_CAPABLE, 1 0)
                      ----------------------------------->
 
-                      DCCP-Resp + Confirm L(CAPABLE, 1, 2 1 0)
+                      DCCP-Resp + Confirm L(MP_CAPABLE, 1, 2 1 0)
             <-----------------------------------
 
                  * agreement on version = 1 *
 ~~~~
+{: #ref-mp-capable-example title='Example of MP-DCCP support negotiation using MP_CAPABLE'}
 
 1. The Client indicates support for both MP-DCCP versions 1 and 0, with a preference
 for version 1.
@@ -537,25 +536,29 @@ These operations are largely inspired by the signals defined in {{RFC8684}}.
   +--------+--------+--------+--------+--------+--------+--------+
    Type=46   Length  MP_OPT=0
 ~~~~
+{: #ref-mp-confirm-format title='Format of the MP_CONFIRM suboption'}
 
 Some multipath options require confirmation from the remote peer (see {{ref-mp-option-confirm}}). Such options will be retransmitted by the sender 
 until a MP_CONFIRM is received or confirmation of options is identified outdated. The further processing of the multipath options in the
 receiving host is not the subject of MP_CONFIRM.
 
-As the transmission of multipath suboptions is subject to out-of-order arrival, suboptions defined in {{ref-mp-option-confirm}}
-SHALL be sent in a DCCP datagram with MP_SEQ {{MP_SEQ}}. This allows to identify outdated suboptions which updates the same
-dataset. In case of MP_ADDADDR, MP_REMOVEADDR the same dataset is identified based on AddressID, whereas the same dataset for MP_PRIO is identified by the subflow in use. An outdated
+As multipath suboptions could arrive out-of-order, suboptions defined in {{ref-mp-option-confirm}}
+MUST be sent in a DCCP datagram with MP_SEQ {{MP_SEQ}}. This allows suboptions to be identified with obsolete datasets that would otherwise conflict with newer datasets. In case of MP_ADDADDR or MP_REMOVEADDR the same dataset is identified based on AddressID, whereas the same dataset for MP_PRIO is identified by the subflow in use. An outdated
 suboption is detected at the receiver if a previous suboption referring to the same dataset contained a higher sequence number
-carried by MP_SEQ. Generating a MP_CONFIRM for suboptions identified outdated is optional.
+carried by MP_SEQ. AN MP_CONFIRM MAY be generated for suboptions that are identified outdated.
 
-Similarly MP_CONFIRM is subject to out-of-order arrival. To ensure that the most recent suboption is confirmed the associated
-MP_SEQ received MUST be echoed. Otherwise inconsistency happens if between updates of a dataset with the same value, another value
-is sent. If the MP_CONFIRM of the second update and the third update itself gets lost, the value of the second update is applied on
-receiver side without being detected by the sender.
+Similarly an MP_CONFIRM could arrive out of order. To ensure that the most recent suboption is confirmed the associated
+MP_SEQ received MUST be echoed. Otherwise inconsistencies could occur, e.g. if three MP_PRIO options are sent one after
+the other on one path in order to first set the path priority to 0, then to 1 and finally to 0 again. Without an associated
+MP_SEQ, a loss of the third MP_PRIO option and a loss of the MP_CONFIRM of the second update and the third update would
+cause the sender to incorrectly believe that the priority value is set to 0 without recognizing that the receiver has applied
+priority value 1.
 
-The length and sending path of the MP_CONFIRM are dependent on the confirmed suboptions and the received MP_SEQ, which will be both copied verbatim and
-appended as list of confirmations. The list structures by first listing the received MP_SEQ followed by the confirmed suboption or suboptions. The same
-rules apply when suboptions with different MP_SEQs are confirmed at once. This might happen if a datagram with MP_PRIO and a first MP_SEQ_1 and another datagram with MP_ADDADDR and a second MP_SEQ_2 are received in short succession. In this case, the structure described above is concatenated resulting in  MP_SEQ_1 + MP_PRIO + MP_SEQ_2 + MP_ADDADDR.
+The length of the MP_CONFIRM option and the path over which the option is sent depend on the confirmed suboptions and the received
+MP_SEQ, which is both copied verbatim and appended as a list of confirmations. The list structures by first listing the received
+MP_SEQ followed by the confirmed suboption or suboptions. The same rules apply when suboptions with different MP_SEQs are confirmed at
+once. This might happen if a datagram with MP_PRIO and a first MP_SEQ_1 and another datagram with MP_ADDADDR and a second MP_SEQ_2 are
+received in short succession. In this case, the structure described above is concatenated resulting in  MP_SEQ_1 + MP_PRIO + MP_SEQ_2 + MP_ADDADDR.
 
 
 |Type | Option Length | MP_OPT           | MP_CONFIRM Sending path                                       |
@@ -631,16 +634,16 @@ Address A1    Address A2                     Address B1    Address B2
 {: #ref-MP_JOIN title='Format of the MP_JOIN Suboption'}
 
 The MP_JOIN option is used by a host to add a new subflow to an existing MP-DCCP
-connection. The Path Token is the SHA256 hash of the derived key (d-key),
+connection and REQUIRES a successfull establishment of the first subflow using MP_KEY.
+The Path Token is the SHA256 hash of the derived key (d-key),
 which was previously exchanged with the MP_KEY option.
 MP_HMAC MUST be set when using MP_JOIN to provide authentication (See
-MP_HMAC for details). Also MP_KEY MUST be set to provide key material
-for authentication purposes.
+{{MP_HMAC}} for details).
 
 The MP_JOIN option includes an "Addr ID" (Address ID) generated by the sender of the option, used to identify the source
 address of this packet, even if the IP header has been changed in
 transit by a middlebox.  The numeric value of this field is generated
-by the sender and must map uniquely to a source IP address for the
+by the sender and MUST map uniquely to a source IP address for the
 sending host.  The Address ID allows address removal ({{MP_REMOVEADDR}})
 without needing to know what the source address at the receiver is,
 thus allowing address removal through NATs.  The Address ID also
@@ -655,7 +658,7 @@ zero.  A host MUST store the mappings between Address IDs and
 addresses both for itself and the remote host.  An implementation
 will also need to know which local and remote Address IDs are
 associated with which established subflows, for when addresses are
-removed from a local or remote host. An Address ID always has to be unique
+removed from a local or remote host. An Address ID always MUST be unique
 over the lifetime of a subflow and can only be re-assigned if sender and
 receiver no longer have them in use.
 
@@ -671,7 +674,7 @@ the new subflow MUST be closed, as specified in {{fallback}}.
 Regular DCCP has the means of sending a Close or Reset signals to abruptly close a
 connection.  With MP-DCCP, a regular Close or Reset only has the scope of the
 subflow over which the signal was received. As such, it will only close the applicable subflow and will not
-affect the remaining subflows concurrently in use on other paths.  A MP-DCCP connection will stay alive at
+affect the remaining subflows in use on other paths.  An MP-DCCP connection will stay alive at
 the data level in order to permit break-before-make handover between
 subflows.  It is therefore necessary to provide an MP-DCCP-level
 "Reset" to allow the abrupt closure of the whole MP-DCCP connection;
@@ -747,7 +750,7 @@ of the handshake procedure for the first subflow, and allows the hosts to agree
 on a single key type to be used as described in {{handshaking}}
 
 If the key type can not be agreed when the MP_KEY option is sent as part of the 
-handshake procedure, the MP-DCCP connection should fallback to regular DCCP as 
+handshake procedure, the MP-DCCP connection MUST fallback to regular DCCP as 
 indicated in {{fallback}}
 
 ### MP_SEQ {#MP_SEQ}

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -64,20 +64,22 @@ author:
   code: IP5 3RE
   country: United Kingdom
   email: stephen.h.johnson@bt.com
-  
+
+normative:
+  RFC2119:
+  RFC4340:
+
 informative:
   I-D.amend-tsvwg-multipath-framework-mpdccp:
   I-D.lhwxz-hybrid-access-network-architecture:
   I-D.muley-network-based-bonding-hybrid-access:
-  I-D.amend-tsvwg-dccp-udp-header-conversion:
   I-D.amend-iccrg-multipath-reordering:
   RFC0793:
   RFC2104:
-  RFC2119:
   RFC3711:
   RFC4043:
   RFC4086:
-  RFC4340:
+  RFC5238:
   RFC5595:
   RFC5596:
   RFC5597:
@@ -97,10 +99,10 @@ informative:
       org: 3GPP
     date: '2020-12-17'
     target: https://www.3gpp.org/ftp//Specs/archive/23_series/23.501/23501-g70.zip
-  website: 
+  multipath-dccp.org: 
     title: Multipath extension for DCCP
     target: https://multipath-dccp.org/
-  paper:
+  MP-DCCP.Paper:
     title: A Framework for Multiaccess Support for Unreliable Internet Traffic using Multipath DCCP
     author:
       -
@@ -127,7 +129,7 @@ informative:
     date: '2019-10-14'
     seriesinfo:
       DOI: 10.1109/LCN44214.2019.8990746
-  slide:
+  IETF115.Slides:
     title: MP-DCCP for enabling transfer of UDP/IP traffic over multiple data paths in multi-connectivity networks
     author:
       -
@@ -166,8 +168,8 @@ network failures.
 Use cases for a Multipath DCCP (MP-DCCP) are mobile devices (e.g., handsets, vehicles) and residential home gateways simultaneously connected to distinct networks as, e.g., 
 a cellular and a Wireless Local Area (WLAN) networks
 or a cellular and a fixed access networks. Compared to existing multipath protocols, such as MPTCP, MP-DCCP provides specific support for non-TCP user
-traffic (e.g., UDP or plain IP).  More details on potential use cases are provided in {{website}}, {{slide}}, and {{paper}}.
-All these use cases profit from an Open Source Linux reference implementation provided under {{website}}.
+traffic (e.g., UDP or plain IP).  More details on potential use cases are provided in {{multipath-dccp.org}}, {{IETF115.Slides}}, and {{MP-DCCP.Paper}}.
+All these use cases profit from an Open Source Linux reference implementation provided under {{multipath-dccp.org}}.
 
 This document specifies a set of extensions to
 DCCP to support multipath operations.  Multipath DCCP provides 
@@ -1440,7 +1442,7 @@ For compatibility reasons, an MP-DCCP implementation SHOULD always announce the 
 Similar to DCCP, MP-DCCP does not provide cryptographic security
 guarantees inherently. Thus, if applications need cryptographic security
 (integrity, authentication, confidentiality, access control, and
-anti-replay protection) the use of IPsec or some other kind of
+anti-replay protection) the use of IPsec, DTLS over DCCP {{RFC5238}} or other
 end-to-end security is recommended;
 Secure Real-time Transport Protocol (SRTP) {{RFC3711}} is one candidate
 protocol for authentication. Together with Encryption of Header
@@ -1449,7 +1451,7 @@ be provided.
 
 As described in {{RFC4340}}, DCCP provides protection against hijacking
 and limits the potential impact of some denial-of-service attacks, but
-DCCP provides no inherent protection against attackers’ snooping on data
+DCCP provides no inherent protection against an on-path attacker snooping on data
 packets. Regarding the security of MP-DCCP no additional risks should be
 introduced compared to regular DCCP. Thereof derived are the
 following key security requirements to be fulfilled by MP-DCCP:
@@ -1507,25 +1509,21 @@ connection-establishment procedures for DCCP.  Further standardized technologies
 addressing NAT type middleboxes are covered by {{RFC5597}}.
 
 {{RFC6773}} specifies UDP Encapsulation for NAT Traversal of DCCP sessions,
-similar to other UDP encapsulations such as for SCTP {{RFC6951}}. The alternative
-U-DCCP approach proposed in {{I-D.amend-tsvwg-dccp-udp-header-conversion}} would
-reduce tunneling overhead. The handshaking procedure for DCCP-UDP
-header conversion or use of a DCCP-UDP negotiation procedure to signal support
-for DCCP-UDP header conversion would require encapsulation during the handshakes
-and use of two additional port numbers out of the UDP port number space, but
-would require zero overhead afterwards.
+similar to other UDP encapsulations such as for SCTP {{RFC6951}}. Future
+specifications by the IETF could specify other methods for DCCP encapsulation.
+
 
 
 # Implementation
 
 The approach described above has been implemented in open source across different testbeds and a new scheduling algorithm has been extensively tested. Also 
-demonstrations of a laboratory setup have been executed and have been published at {{website}}.
+demonstrations of a laboratory setup have been executed and have been published at {{multipath-dccp.org}}.
 
 
 # Acknowledgments
 
-Due to the great spearheading work of the Multipath TCP authors in {{RFC6824}}/{{RFC8684}}, some text
-passages were copied almost unmodified from these documents.
+{{RFC6824}} and {{RFC8684}} defined Multipath TCP and provided important
+inputs for this specification
 
 The authors gratefully acknowledge significant input into this document from Dirk von Hugo, Nathalie Romo Moreno, Omar Nassef, Mohamed Boucadair, Simone Ferlin, and Behcet Sarikaya.
 
@@ -1578,7 +1576,7 @@ IANA is requested to create a new 'MP-DCCP Suboptions' registry within the DCCP 
 | MP_OPT>11| Unassigned      | Reserved for future MP-DCCP suboptions           |                   |
 {:#ref-add-proto-opt-list title='MP-DCCP Suboptions registry'}
  
-Future MP-DCCP sub-options with MP_OPT>11 can be assigned from this registry using the Specification Required policy (Section 4.6 of {{RFC8126}}).
+Future MP-DCCP sub-options with MP_OPT>11 are assigned from this registry using the Specification Required policy (Section 4.6 of {{RFC8126}}).
 
 In addition IANA is requested to assign a new DCCP Reset Code value 13 (or TBD) in the DCCP Reset Codes Registry, with the short description "Abrupt MP termination".  Use of this reset code is defined in section {{MP_FAST_CLOSE}}.
 
@@ -1659,7 +1657,7 @@ character of DCCP. The multipath sequence numbers included in MP-DCCP (see {{MP_
 adding optional mechanisms for data stream packet reordering 
 at the receiver.  Information from the MP_RTT multipath option ({{MP_RTT}}), 
 DCCP path sequencing and the DCCP Timestamp Option provide further means 
-for advanced reordering approaches, e.g., as described in {{I-D.amend-iccrg-multipath-reordering}}.
+for advanced reordering approaches, e.g., as proposed in {{I-D.amend-iccrg-multipath-reordering}}.
 Such mechanisms do, however, not affect interoperability
 and are not part of the MP-DCCP protocol.  Many 
 applications that use unreliable transport protocols can also inherently deal 

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1447,7 +1447,7 @@ The path mobility strategy provides the use of a single path with a seamless han
 Some of the DCCP subflows of a MP-DCCP connection might become inactive due to either the occurrence of certain error conditions (e.g., DCCP timeout, packet loss threshold, RTT threshold, closed/removed) or adjustments from the MP-DCCP user.
 When there is outbound data to send and the primary path becomes inactive (e.g., due to failures) or de-prioritized, the MP-DCCP endpoint SHOULD try to send the data through an alternate path with a different source or destination address (depending on the point of failure), if one exists. This process SHOULD respect the path priority configured by MP_PRIO or if not available pick the most divergent source-destination pair from the original used source-destination pair.
 Note: Rules for picking the most appropriate source-destination pair are an implementation decision and are not specified within this document.
-Path mobility is supported in the current Linux reference implementation {{website}}.
+Path mobility is supported in the current Linux reference implementation {{multipath-dccp.org}}.
 
 ### Concurrent path usage
 Different to a path mobility strategy, the selection between MP-DCCP

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -487,7 +487,7 @@ for version 1.
 
 3. MP-DCCP is then enabled between the Client and Server with version 1.
 
-If the version negotiation fails or the MP_CAPABLE feature is not present in the DCCP-Request or DCCP-Response packets of the initial handshake procedure, the MP-DCCP connection SHOULD fall back to regular DCCP or MUST be closed. Further details are specified in {{fallback}}
+If the version negotiation fails or the MP_CAPABLE feature is not present in the DCCP-Request or DCCP-Response packets of the initial handshake procedure, the MP-DCCP connection SHOULD fallback to regular DCCP or MUST be closed. Further details are specified in {{fallback}}
 
 
 ## Multipath Option {#MP_OPT}
@@ -1072,23 +1072,23 @@ at the requested Address ID, the receiver will silently ignore the request.
  
 A subflow that is still functioning MUST be closed with a DCCP-Close
 exchange as in regular DCCP, rather than using this option. For more
-information, see Section {{closing}}.
+information, see {{closing}}.
 
 
 ### MP_PRIO {#MP_PRIO}
 
 In the event that a single specific path out of the set of available
 paths shall be treated with higher priority compared to the others
-when making scheduling decisions for user plane traffic, a host may 
+when making scheduling decisions for payload traffic, a host may 
 wish to signal such change in priority  to the peer.
 One reason for such behavior is due to the different costs involved in
 using different paths (e.g., WiFi is free while cellular has limit on
 volume, 5G has higher energy consumption). Also, the priority of a path
-may be subject to dynamic changes, for example when the mobile runs out
+could change, for example when the mobile runs out
 of battery, the usage of only a single path may be the preferred choice
-of the user. Therefore, the path priority should be considered as hints 
+of the user. Therefore, the path priority SHOULD be considered as hints 
 for the packet scheduler when making decisions which path to use for 
-user plane traffic.
+payload traffic.
 
 
 The MP_PRIO suboption, shown below, can be used to set a priority flag
@@ -1116,11 +1116,10 @@ The following values are available for Prio field:
        congested or are not available. This is the recommended setting for
        paths that have costs or data caps as these paths will be used less
        frequently then primary paths.
-*   3 - 15: Primary: can use the path in any way deemed reasonable by peer. 
-       The path will always be used for packet scheduling decisions. The 
+*   3 - 15: Primary: The path can be used for packet scheduling decisions. The 
        priority number indicates the relative priority of one path over the 
        other for primary paths. Higher numbers indicate higher priority. 
-       The peer should consider sending more traffic over higher priority paths. 
+       The peer should consider sending traffic first over higher priority paths. 
        This is the recommended setting for paths that do not have a cost or 
        data caps associated with them as these paths will be frequently used.
 
@@ -1133,7 +1132,7 @@ Example use cases include:
 2) Setting Wi-Fi path to Primary and Cellular to Standby. In this case Wi-Fi
    will be used and Cellular only, if the Wi-Fi path is not available. 
 3) Setting Wi-Fi path to Primary and Cellular path to Primary. In this case,
-   all packets can be scheduled  over all paths at all time. 
+   both paths can be used when making packet scheduling decisions. 
 
 If not specified, the default behavior is, that a path can always be used for 
 packet scheduling decisions (MP_PRIO=3), if the path has been established and 
@@ -1158,7 +1157,7 @@ in which MP_PRIO is sent. Further details are given in {{MP_CONFIRM}}.
 ~~~~
 {: #ref-MP_CLOSE title='Format of the MP_CLOSE Suboption'}
 
-For a graceful shutdown of a MP-DCCP connection, MP_CLOSE is used to communicate this to a peer host. On all subflows, the regular termination procedure as described in {{RFC4340}} MUST be initiated using MP_CLOSE in the initial packet (either a DCCP-CloseReq or a DCCP-Close). In the case where a DCCP-CloseReq is used, the following DCCP-Close MUST carry the MP_CLOSE as well. At the initiator of the DCCP-CloseReq all sockets, including the MP-DCCP connection socket, transition to CLOSEREQ state. To protect unauthorized shutdown of a multi-path connection, the selected Key Data of the peer host during the handshaking procedure MUST be carried by the MP_CLOSE option and validated by the peer host. Note, Key Data is different between MP_CLOSE option carried by DCCP-CloseReq or DCCP-Close.
+An MP-DCCP connection can be gracefully closed by sending and MP_CLOSE to the peer host. On all subflows, the regular termination procedure as described in {{RFC4340}} MUST be initiated using MP_CLOSE in the initial packet (either a DCCP-CloseReq or a DCCP-Close). In the case where a DCCP-CloseReq is used, the following DCCP-Close MUST carry the MP_CLOSE as well. At the initiator of the DCCP-CloseReq all sockets, including the MP-DCCP connection socket, transition to CLOSEREQ state. To protect unauthorized shutdown of a multi-path connection, the selected Key Data of the peer host during the handshaking procedure MUST be carried by the MP_CLOSE option and validated by the peer host. Note, Key Data is different between MP_CLOSE option carried by DCCP-CloseReq or DCCP-Close.
 
 On reception of a first DCCP-CloseReq carrying a MP_CLOSE with valid Key Data, or due to a local decision, all subflows transition to the CLOSING state before transmitting a DCCP-Close carrying MP_CLOSE. In this case, the MP-DCCP connection socket on the host sending the DCCP-Close reflects the state of the initial subflow used during handshake with MP_KEY option. If the initial subflow no longer exists, the state moves immediately to CLOSED.
 
@@ -1173,7 +1172,7 @@ Contrary to a MP_FAST_CLOSE {{MP_FAST_CLOSE}}, no single-sided abrupt terminatio
 
 This section reserves a MP-DCCP sub-option to define and specify any experimental additional feature for improving and optimization of MP-DCCP protocol. This
 option may be applicable to specific environments or scenarios according to potential new requirements and meant for private use only at this stage. MP_OPT 
-feature number 11 is foreseen with an exemplary description as below:
+feature number 11 is specified with an exemplary description as below:
 
 ~~~~
                      1                   2                   3
@@ -1343,9 +1342,8 @@ is reached. Note that receiving a reset code 9 for secondary subflows SHOULD NOT
 subflows. If necessary, these subflows are terminated in a subsequent step using the procedures described in
 this section. 
 
-When a host wants to terminate an  MP-DCCP connection, it is RECOMMENDED that the host
-initiates the DCCP connection termination as per {{RFC4340}} on each subflow with the first packet on 
-each subflow carrying MP_CLOSE (see {{MP_CLOSE}}).
+A host terminates an MP-DCCP connection using the DCCP connection termination specified in section 5.5 of
+{{RFC4340}} on each subflow with the first packet on each subflow carrying MP_CLOSE (see {{MP_CLOSE}}).
 
       Host A                                   Host B
       ------                                   ------
@@ -1371,7 +1369,7 @@ subflows, each carrying the MP_FAST_CLOSE option.
 ## Fallback {#fallback}
 
 When a subflow fails to operate following MP-DCCP intended behavior, it is 
-necessary to proceed with a fall back. This may be either falling back 
+necessary to proceed with a fallback. This may be either falling back 
 to regular DCCP {{RFC4340}} or removing a problematic subflow. The main reasons for 
 subflow failing include: no MP support at peer host, failure to negotiate protocol
 version, loss of MP-DCCP suboptions, faulty/non-supported MP-DCCP options or modification
@@ -1380,15 +1378,16 @@ of payload data.
 At the start of an MP-DCCP connection, the handshake ensures exchange of MP-DCCP feature and
 options and thus ensures that the path is fully MP-DCCP capable. If during the
 handshake procedure it appears that DCCP-Request or DCCP-Response
-messages don’t carry the MP_CAPABLE feature, the MP-DCCP connection will not be 
-established and the handshake SHOULD fall back to regular DCCP or MUST be closed. 
+messages do not carry the MP_CAPABLE feature, the MP-DCCP connection will not be 
+established and the handshake SHOULD fallback to regular DCCP (if this is not 
+possible it MUST be closed). 
 
-The same fallback SHOULD take place if the endpoints fail to agree on a protocol
-version to use during the Multipath Capable feature negotiation, which is described
-in {{mp_capable}}. The protocol version negotiation distinguishes between negotiation
+A connection SHOULD fallback to regular DCCP if the endpoints fail to agree on a
+protocol version to use during the Multipath Capable feature negotiation. This is described in
+{{mp_capable}}. The protocol version negotiation distinguishes between negotiation
 for the initial connection establishment, and addition of subsequent subflows. If
 protocol version negotiation is not successful during the initial connection establishment,
-MP-DCCP connection will fall back to regular DCCP. 
+MP-DCCP connection will fallback to regular DCCP. 
 
 Similar procedure MUST be applied if the MP_KEY {{MP_KEY}} Key Type cannot be negotiated,
 a final ACK carrying MP_KEY with wrong Key-A/Key-B is received or MP_KEY option is malformed.
@@ -1396,8 +1395,9 @@ a final ACK carrying MP_KEY with wrong Key-A/Key-B is received or MP_KEY option 
 If a subflow attempts to join an existing MP-DCCP connection, but MP-DCCP options or MP_CAPABLE
 feature are not present or are faulty in the handshake procedure, that subflow MUST be closed.
 This is especially the case if a different MP_CAPABLE version than the originally negotiated
-version is used. Also non-verifiable MP_HMAC {{MP_HMAC}} or MP_JOIN Path Token {{MP_JOIN}} as
-part of the subsequent flow establishment MUST lead to a subflow closing.
+version is used. Reception of a non-verifiable MP_HMAC ({{MP_HMAC}}) or an invalid
+MP_JOIN Path Token {{MP_JOIN}} during flow establishment MUST cause the
+subfloor to be closed.
 
 Another relevant case is when payload data is modified by middleboxes. DCCP uses 
 checksum to protect the data, as described in section 9 of {{RFC4340}}. A checksum will 
@@ -1405,14 +1405,15 @@ fail if the data has been changed in any way. All data from the start of the seg
 failed the checksum onwards cannot be considered trustworthy. DCCP defines that if 
 the checksum fails, the receiving endpoint MUST drop the application data and report 
 that data as dropped due to corruption using a Data Dropped option (Drop Code 3, 
-Corrupt). If this happens in an MP-DCCP connection, the affected subflow can either be closed
-or other action can be taken. 
+Corrupt). If data is dropped due to corruption for an MP-DCCP connection, the affected
+subflow MAY be closed.
+
 
 ## Congestion Control Considerations
 
-Senders MUST manage per-path congestion status, and SHOULD avoid to send
-more data on a given path than congestion control on that path
-allows.
+Senders MUST manage per-path congestion status, and avoid to
+sending more data on a given path than congestion control
+for each path allows.
 
 When a Multipath DCCP connection uses two or more paths, there is no
 guarantee that these paths are fully disjoint.  When two (or more

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -987,10 +987,10 @@ accidentally setting up a new subflow upon the signal of a private
 address.  Further security considerations around the issue of
 MP_ADDADDR messages that accidentally misdirect, or maliciously direct,
 new MP_JOIN attempts are discussed in {{security}}.
-In case a sending host of a MP_ADDADDR knows about the inability
-to establish incoming subflows on a particular address, a MP_ADDADDR
-SHOULD NOT advertise this address unless sending host has new knowledge
-about the ability. Such ability information can be obtained from local
+If a sending host of an MP_ADDADDR knows that no incoming subflows can
+be established at a particular address, an MP_ADDADDR SHOULD NOT
+announce that address unless the sending host has new knowledge about
+the possibility to do so. Such ability information can be obtained from local
 firewall or routing settings, knowledge about availability of external
 NAT or firewall, or from connectivity checks performed by the
 host/application.
@@ -999,7 +999,7 @@ The reception of an MP_ADDADDR message is acknowledged using MP_CONFIRM
 ({{MP_CONFIRM}}). Using this mechanism reliable exchange of address
 information is ensured.
 
-A host can send an MP_ADDADDR message with an already assigned Address
+A host MAY send an MP_ADDADDR message with an already assigned Address
 ID, but the Address MUST be the same as previously assigned to this
 Address ID, and the Port MUST be different from one already in use
 for this Address ID.  If these conditions are not met, the receiver

--- a/draft-ietf-tsvwg-multipath-dccp.mkd
+++ b/draft-ietf-tsvwg-multipath-dccp.mkd
@@ -1054,9 +1054,9 @@ DCCP-Close and DCCP-Reset by client and server, respectively on the affected
 subflow(s) (if possible), as a courtesy to cleaning up middlebox state, before
 cleaning up any local state.
 
-Address removal is undertaken by ID, so as to permit the use of NATs and
-other middleboxes that rewrite source addresses.  If there is no address
-at the requested ID, the receiver will silently ignore the request.
+Address removal is done by Address ID to allow the use of NATs and other
+middleboxes that rewrite source addresses.  If there is no address
+at the requested Address ID, the receiver will silently ignore the request.
 
 ~~~~
                      1                   2                   3
@@ -1070,7 +1070,7 @@ at the requested ID, the receiver will silently ignore the request.
 ~~~~
 {: #refMP_REMOVEADDR title='Format of theMP_REMOVEADDR Suboption'}
  
-A subflow that is still functioning MUST be closed with a DCCP-Close or
+A subflow that is still functioning MUST be closed with a DCCP-Close
 exchange as in regular DCCP, rather than using this option. For more
 information, see Section {{closing}}.
 


### PR DESCRIPTION
```
====

In section 2, I saw:

    The number of concurrent DCCP subflows can vary during the lifetime
    of a Multipath DCCP connection.  The details of the path management
    decisions for when to add or remove subflows are outside the scope of
    this document.
I’d suggest:
    The number of MP-DCCP subflows can vary during the lifetime
    of a Multipath DCCP connection.  The details of the path management
    decisions for when to add or remove subflows are outside the scope of
    this document.
or /active subflows/ if that somehow makes sense, but not concurrent!
====
I’d be happy to see the reference to RFC3124 and discussion of CM 
disappear, since this was not a great story. However, I would not resist 
if you insist on keeping this.
===
Alas you really ought not to mention or reference RFC5634, that also 
didn't have a great outcome and isn't a real issue for MP-DCCP.
===
I saw:
affect the remaining subflows concurrently in use on other paths
I’d suggest:
affect the remaining MP-DCCP subflows in use on other paths
===
/the right order to/the originally transmitted order/
===
- You do not say whether DCCP guarantees in-order delivery or not,
which might be important for a reviewer to understand the context! (I 
think we know:-) )
===
3.1
I saw:
DCCP endpoints uses
- I think this could better be:
DCCP endpoints negotiate
====
3.1:/Multipath Capable feature has feature/The Multipath Capable 
(MP-Capable) feature has feature / ... is MP-Capable hyphenated or does 
it use an underscore?
===
3.1:/ The setting of Multipath Capable MUST/ The setting of the 
MP-Capable feature MUST/
===
3.1:/the Multipath Capable feature is allowed/the MP-Capable feature is 
allowed/
===
In example, please add a figure legend?
===
In example, could you change: /CAPABLE/MP-Capable/ - to be consistent?
===
3.1: Check MP-Capable is consistently hyphenated or uses an underscore.
===
3.2 define MP_Opt and then use consistently?
===
Add a figure legend to figure in 3.2.1? (all figures ought to have legends)
===
  As the transmission of multipath suboptions is subject to out-of-
    order arrival, suboptions defined
- Is this not subject to, but can be subject to.... could we say:
Multipath suboptions could arrive out of order, the suboptions defined
===
/SHALL be sent/MUST be sent/ - for consistency.
===
/This allows to identify outdated suboptions which updates the same 
dataset. /
- That didn’t quite parse to me. Please rewrite.
===
/In case of MP_ADDADDR, MP_REMOVEADDR the/
is this:
/In the case of MP_ADDADDR or MP_REMOVEADDR the/
===
/Generating a MP_CONFIRM for suboptions
    identified outdated is optional./
- this seems like a requirement, something like:
/An MP_CONFIRM MAY be generated for suboptions
that are identified as outdated./
===
/ Similarly MP_CONFIRM is subject to out-of-order arrival./
ought this to be something like:
/An MP_CONFIRM could arrive out of order/
===
/Otherwise inconsistency happens if between
    updates of a dataset with the same value, another value is sent./
- I wasn’t able to udnerstand, butcould be:
/An inconsistency could occur if another value is sent... ..../
===
I think this is an example, but you ought to say that if it is:
/If
    the MP_CONFIRM of the second update and the third update itself gets
    lost, the value of the second update is applied on receiver side
    without being detected by the sender./
... it also seems to need a little rewording.
===
The para starting:
/The length and sending path of the.../
... seems to need a little rewording.
===
/ Also MP_KEY MUST be set to
    provide key material for authentication purposes./
- doesn’t seem a complete requirement, is this:
/ An MP-JOIN MUST also provide an MP_KEY to
    provide key material for authentication./
===
/The numeric value of this field is generated by the
    sender and must map uniquely to a source IP address for the sending
    host.  /
- why is this not a MUST?
===
/ An
    Address ID always has to be unique over the lifetime of a subflow and
    can only be re-assigned if sender and receiver no longer have them in
    use./
- why is this not a MUST?
===
/ A MP-DCCP connection/ An MP-DCCP connection/
===
    If the key type can not be agreed when the MP_KEY option is sent as
    part of the handshake procedure, the MP-DCCP connection should
    fallback to regular DCCP as indicated in Section 3.6
- why is this not SHOULD? (you need to explain what case would allow 
this to be OK, if it is SHOULD).
- So, why actually is this not MUST?
===
/MUST be sent with any DCCP-Data and DCCP-
    DataACK packet./
- /any/each/ ... i.e. isn’t it all of the data packets and acks?
===
/As all this multipath
    options come along with an individual MP_HASH option, this requires
    the MP_HASH to be correctly associated.
/All these multipath options include an individual MP_HASH option. This 
ensures the MP_HASH is correctly associated./
===
/ If the
    suboption to be authenticated was either MP_ADDADDR or MP_REMOVEADDR,
    the receiving host SHOULD silently ignore it/
- I’m not arguing, but you do not explain how the SHOULD would be 
violated, is this a MUST?
===
/If the suboption to be authenticated was MP_JOIN, it
    MUST lead to a subflow closing (see Section 3.6)/
If the suboption to be authenticated was MP_JOIN, the subflow
    MUST be closed (see Section 3.6)/
===
/In case the path individual RTTs/In the case that the path individual RTTs/
===
/there may be cases (such as port-based load balancing) where
    the explicit specification of a different port is required. /
- please in this case avoid /may/ here, and replace by /could/ for 
avoidance of doubt.
===
I’m unsure of:
/If no
    port is specified, the receiving peer SHOULD assume that any attempt
    to connect to the specified address has to be on the same port as is
    already in use by the subflow on which the MP_ADDADDR signal was
    sent./
could this be something like:
/If no
    port is specified, the receiving peer SHOULD assume that any attempt
    to connect to the specified address uses the port
    already used by the subflow on which the MP_ADDADDR signal was
    sent./
- Why SHOULD? Isn’t this MUST?
===
/MAY discard incoming address advertisements at will,/
MAY discard incoming address advertisements,/
===
/ It is not desirable
    to prohibit this, since there may be cases where both hosts have
    additional interfaces on the same private network, and a host MAY
    want to advertise such addresses. /
- I understand the intent, but I do not understand the requirement, 
could it be:
/ It is not desirable
    to prohibit this, since there may be cases where both hosts have
    additional interfaces on the same private network. A host MAY
    advertise a private address. /
===
/ In case a
    sending host of a MP_ADDADDR knows about the inability to establish
    incoming subflows on a particular address, a MP_ADDADDR SHOULD NOT
    advertise this address unless sending host has new knowledge about
    the ability./
- This isn’t clear to me. Please reword.
==
I could not parse:
    Address removal is undertaken by ID, so as to permit the use of NATs
    and other middleboxes that rewrite source addresses.
===
/   A subflow that is still functioning MUST be closed with a DCCP-Close
    or exchange as in regular DCCP, rather than using this option. /
- That does not seem clear, make sure the requirement sentence captures 
what triggers the CLOSE.
===
/For
    more information, see Section Section 3.5./
- double section.
===
/scheduling decisions for user plane traffic/
- is /user plane traffic/ the correct term and is this used consistently?
===
/Also, the priority of a
    path may be subject to dynamic changes,/
- does that mean /could change/ or something else?
===
/Therefore, the path priority should be
    considered as hints for the packet scheduler when making decisions
    which path to use for user plane traffic./
- is this /SHOULD/?
===
/Primary: can use the path in any way deemed reasonable by
       peer. /
/Primary: The path can be used for packet scheduling
       decisions./
-the word  /always/ also seemed odd.
===
/ The peer should consider sending more
      traffic over higher priority paths./
- seems like not the correct thing to say, do we even need to say more 
than the previous sentence?
===
/In this case, all packets can be scheduled over all
    paths at all time./
- This is concurrent multipath.
- You could avoid this by saying “both paths can be used when making 
packet scheduling decisions” ... which avoid saying concurrently.
===
/   For a graceful shutdown of a MP-DCCP connection, MP_CLOSE is used to
    communicate this to a peer host. /
    An MP-DCCP connection can be gracefully closed by sending and 
MP_CLOSE to
    the peer host. /
===
3.7.  Congestion Control Considerations

    Senders MUST manage per-path congestion status, and SHOULD avoid to
    send more data on a given path than congestion control on that path
    allows.

- I’m unsure about the should here and I am very sure the MUST is 
correct. Can I propose:

    Senders MUST manage per-path congestion status, and avoid to
    sending more data on a given path than congestion control
    for each path allows.
===
/is foreseen/is specified/
===
Can we simply restate this:
/   When a host wants to terminate an MP-DCCP connection, it is
    RECOMMENDED that the host initiates the DCCP connection termination
    as per [RFC4340] /
/A host terminates an MP-DCCP connection using the DCCP connection 
termination
    specified in section 5.5 of [RFC4340]
===
/don't carry/do not carry/
===
/and the handshake SHOULD fall back to regular DCCP or MUST be closed./
- is this:
/and the handshake SHOULD fall back to regular DCCP (if this is not 
possible it MUST be closed)./
===
/  The same fallback SHOULD take place if the endpoints fail to agree on
    a protocol version to use during the Multipath Capable feature
    negotiation, which is described in Section 3.1. /
/  A connection SHOULD fall back to regular DCCP if the endpoints fail 
to agree on
    a protocol version to use during the Multipath Capable feature
    negotiation. This is described in Section 3.1./
===
/Also non-verifiable MP_HMAC
    Section 3.2.6 or MP_JOIN Path Token Section 3.2.2 as part of the
    subsequent flow establishment MUST lead to a subflow closing.
/Reception of a non-verifiable MP_HMAC (Section 3.2.6) or an invalid
MP_JOIN Path Token Section 3.2.2 during flow establishment MUST cause the
subfloor to be closed./
===
/MUST lead to a subflow closing./MUST result in a Close flow the subflow./
===
  /If
    this happens in an MP-DCCP connection, the affected subflow can
    either be closed or other action can be taken./
  If data is dropped due to
    corruption for an MP-DCCP connection, the affected subflow MAY be 
closed./
... do we need this clause at all, if we do then please rephrase as above.
===
Please check /fall back/ and /fallback/ and be consistent.
====
/ use of IPsec or some other kind of
    end-to-end security is recommended /
  use of IPsec or other
    end-to-end security is recommended/
====
The IETF has defined DTLS for SCTP, so that also ought to be 
recommended, or otherwise noted.
===
/protection against attackers' snooping
    on data packets/
protection against an on-path attacker snooping
    on data packets/
====
This text can’t be included in a PS, since it is a downref to non-IEYTF 
work items:
/ The alternative U-DCCP approach proposed in
    [I-D.amend-tsvwg-dccp-udp-header-conversion] would reduce tunneling
    overhead.  The handshaking procedure for DCCP-UDP header conversion
    or use of a DCCP-UDP negotiation procedure to signal support for
    DCCP-UDP header conversion would require encapsulation during the
    handshakes and use of two additional port numbers out of the UDP port
    number space, but would require zero overhead afterwards./

You could say:
/Future specifications by the IETF could specify other methods for DCCP 
encapsulation./
====
This might be true, but it also could result in a more complex process 
for progression, I’d recommend using slightly different text:
/ Due to the great spearheading work of the Multipath TCP authors in
    [RFC6824]/[RFC8684], some text passages were copied almost unmodified
    from these documents./
e.g.
/ [RFC6824] and [RFC8684] defined Multipath TCP and provided important
inputs for this specification./
===
/ Future MP-DCCP sub-options with MP_OPT>11 can be assigned from this
    registry using the Specification Required policy (Section 4.6 of
    [RFC8126])./
- change /can be/are/.
===
Section 9
- This needs normative references to at least:
DCCP
RFC2119
RFC4340
===
Please amend the citation token for [paper] and [slide] - the later 
should be something like [IETF115.Slides]
===
To avoid a downwards style looking ref, you may like to say “proposal 
in”, when saying:
/DCCP path sequencing and
    the DCCP Timestamp Option provide further means for advanced
    reordering approaches, e.g., as described in
    [I-D.amend-iccrg-multipath-reordering]/
===
```